### PR TITLE
 Replace Task.leftShift by Task.doLast

### DIFF
--- a/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
+++ b/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
@@ -24,7 +24,7 @@ class ESLintPlugin implements Plugin<Project> {
         def esLintPluginConvention = new ESLintPluginConvention(project)
         project.convention.plugins.eslint = esLintPluginConvention
 
-        project.task('eslint') << {
+        project.task('eslint').doLast {
             project.exec {
                 executable esLintPluginConvention.getExecutable()
                 args esLintPluginConvention.getArguments()


### PR DESCRIPTION
`Task << Closure` will be deprecated in Gradle 5.0. Use `Task.doLast Closure` instead.