### PR TITLE
Switching from << to doLast{}

### DIFF
--- a/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
+++ b/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
@@ -24,10 +24,12 @@ class ESLintPlugin implements Plugin<Project> {
         def esLintPluginConvention = new ESLintPluginConvention(project)
         project.convention.plugins.eslint = esLintPluginConvention
 
-        project.task('eslint') << {
-            project.exec {
-                executable esLintPluginConvention.getExecutable()
-                args esLintPluginConvention.getArguments()
+        project.task('eslint') {
+            doLast {
+                project.exec {
+                    executable esLintPluginConvention.getExecutable()
+                    args esLintPluginConvention.getArguments()
+                }
             }
         }
 


### PR DESCRIPTION
Usage of << has been issuing deprecation notices on newer Gradle versions.
Specifically the warning message is:
```
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
```

This change is backwards compatible and also avoids these warnings