### PR TITLE
Added support for node.js path (if not installed globally)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a Gradle plugin for running [ESLint](http://eslint.org/) as part of your
                 }
             }
             dependencies {
-                classpath "gradle.plugin.com.github.scobal.eslint:gradle-eslint-plugin:1.0.5"
+                classpath "gradle.plugin.com.github.scobal.eslint:gradle-eslint-plugin:1.0.6"
             }
         }
 
@@ -37,27 +37,28 @@ http://eslint.org/docs/user-guide/command-line-interface
 This is a list of the available options for use inside the `eslint` configuration block:
 
 
-|       Option      | Description |
-| ----------------- |------------ |
-| `executable` | The path to an eslint executable (default is `"eslint"`), eg: `"/usr/bin/eslint"` 
-| `yarnPath` | The path to yarn package manager, which will indicate to plugin to run eslint via yarn rather than directly. This can be either directory containing yarn or full path including yarn executable. Plugin has logic built to add '.cmd' suffix for the Windows Operating System, eg: `"build/yarn/bin"`, `"/usr/bin/yarn"` 
+| Option            | Description |
+|-------------------|------------ |
+| `executable`      | The path to an eslint executable (default is `"eslint"`), eg: `"/usr/bin/eslint"` 
+| `nodePath`        | The path to Node.js will be prefixed to the environemnt path of the executable process. This is needed when the Node.js is not globally installed, eg: `"build/node"` 
+| `yarnPath`        | The path to yarn package manager, which will indicate to plugin to run eslint via yarn rather than directly. This can be either directory containing yarn or full path including yarn executable. Plugin has logic built to add '.cmd' suffix for the Windows Operating System, eg: `"build/yarn/bin"`, `"/usr/bin/yarn"` 
 | `ignoreExitValue` |  Boolean to ignore eslint's exit value (default is `false`), eg: `true`
-| `inputs` | A list of files, directories and/or globs (default is `["src"]`), eg: `["service.js", "src/controllers/", "**/*.js"]`
-| `config` | The path to an eslint configuration file, eg: `"/home/scobal/esconfig"`
-| `noEslintrc` |  Boolean to disable the use of .eslintrc, eg: `true`
-| `env` | A list of environments as strings, eg: `["environment_1", "environment_2"]`
-| `ext` | A list of Javascript file extensions as strings, eg: `[".js", ".jsx"]`
-| `global` | A list of global variables as strings, eg: `["global_1", "global_1"]`
-| `parser` | The parser to be used, eg: `"espree"`
-| `parserOptions` | Specify parser options
-| `cache` | Boolean to only check changed files, eg: `true`
-| `cacheFile` | The path to an eslint cache file, eg: `"/tmp/eslint_cache/file"`
-| `cacheLocation` | The path to an eslint cache file or directory, eg: `"/tmp/eslint_cache"`
-| `rulesDir` | A list of directories with additional rules, eg: `["/eslint/rules_1", "/eslint/rules_2"]`
-| `plugin` | A list of plugins as strings, eg: `["plugin_1", "plugin_2"]`
-| `rule` | Specify rules
-| `outputFile` | The path to the output file, eg: `"/home/scobal/report.out"`
-| `format` | The format of the output file, eg: `"checkstyle"`
+| `inputs`          | A list of files, directories and/or globs (default is `["src"]`), eg: `["service.js", "src/controllers/", "**/*.js"]`
+| `config`          | The path to an eslint configuration file, eg: `"/home/scobal/esconfig"`
+| `noEslintrc`      |  Boolean to disable the use of .eslintrc, eg: `true`
+| `env`             | A list of environments as strings, eg: `["environment_1", "environment_2"]`
+| `ext`             | A list of Javascript file extensions as strings, eg: `[".js", ".jsx"]`
+| `global`          | A list of global variables as strings, eg: `["global_1", "global_1"]`
+| `parser`          | The parser to be used, eg: `"espree"`
+| `parserOptions`   | Specify parser options
+| `cache`           | Boolean to only check changed files, eg: `true`
+| `cacheFile`       | The path to an eslint cache file, eg: `"/tmp/eslint_cache/file"`
+| `cacheLocation`   | The path to an eslint cache file or directory, eg: `"/tmp/eslint_cache"`
+| `rulesDir`        | A list of directories with additional rules, eg: `["/eslint/rules_1", "/eslint/rules_2"]`
+| `plugin`          | A list of plugins as strings, eg: `["plugin_1", "plugin_2"]`
+| `rule`            | Specify rules
+| `outputFile`      | The path to the output file, eg: `"/home/scobal/report.out"`
+| `format`          | The format of the output file, eg: `"checkstyle"`
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 group = 'com.github.scobal.eslint'
-version = '1.0.5'
+version = '1.0.6'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
+++ b/src/main/groovy/com/github/scobal/eslint/ESLintPlugin.groovy
@@ -44,6 +44,11 @@ class ESLintPlugin implements Plugin<Project> {
 
             doLast {
                 project.exec {
+                    if (esLintPluginConvention.nodePath != null) {
+                        String environmentPath = getEnvironmentPath(environment)
+                        environment 'PATH', buildEnvironmentPath(esLintPluginConvention.nodePath, environmentPath)
+                    }
+
                     executable determineExecutable(esLintPluginConvention)
                     args determineArguments(esLintPluginConvention)
                     ignoreExitValue = esLintPluginConvention.ignoreExitValue
@@ -69,6 +74,18 @@ class ESLintPlugin implements Plugin<Project> {
         project.tasks.named('check') {
             dependsOn(esLintTask)
         }
+    }
+
+    private static String getEnvironmentPath(Map<String, Object> environment) {
+
+        Os.isFamily(Os.FAMILY_WINDOWS) ? environment.Path : environment.PATH
+    }
+
+    private static String buildEnvironmentPath(String nodePath, String environmentPath) {
+
+        def separator = Os.isFamily(Os.FAMILY_WINDOWS) ? ';' : ':'
+
+        "$nodePath$separator$environmentPath"
     }
 
     private static String determineExecutable(ESLintPluginConvention convention) {

--- a/src/main/groovy/com/github/scobal/eslint/ESLintPluginConvention.groovy
+++ b/src/main/groovy/com/github/scobal/eslint/ESLintPluginConvention.groovy
@@ -21,6 +21,7 @@ class ESLintPluginConvention {
     public static final String ESLINT = 'eslint'
 
     def String executable = ESLINT
+    def String nodePath = null
     def String yarnPath = null
     def boolean ignoreExitValue = false
 

--- a/src/test/groovy/com/github/scobal/eslint/ESLintPluginConventionTest.groovy
+++ b/src/test/groovy/com/github/scobal/eslint/ESLintPluginConventionTest.groovy
@@ -38,6 +38,7 @@ class ESLintPluginConventionTest {
         } else {
             assertEquals("eslint", convention.getExecutable())
         }
+        assertNull(convention.getNodePath())
         assertNull(convention.getYarnPath())
         assertEquals(false, convention.getIgnoreExitValue())
         assertEquals(['src'], convention.getInputs())


### PR DESCRIPTION
- Added new nodePath property for use cases where Node.js is not installed globally
- Updated existing unit tests and README.

I didn't realize that on our Jenkins Node.js is not installed globally and eslint wasn't working so this fixes that issue.

![image](https://github.com/scobal/gradle-eslint-plugin/assets/5693250/6d4c8de2-5a51-44a8-a020-fd8ed23b8540)

